### PR TITLE
Making es5-shim loadable with AMD module loaders

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -10,7 +10,7 @@
     MIT License. http://github.com/280north/narwhal/blob/master/README.md
 */
 
-(function (undefined) {
+(typeof define === "function" ? define : function($) { $(); })(function(require, exports, module, undefined) {
 
 /**
  * Brings an environment as close to ECMAScript 5 compliance
@@ -835,4 +835,4 @@ if (!String.prototype.trim) {
     };
 }
 
-})();
+});


### PR DESCRIPTION
There is at least one use case with [ace](https://github.com/ajaxorg/ace/) where it would be useful as currently it just uses a copy of this module with to make it loadable with requirejs. Also I think it's generally useful and easy to add. 
