### PR TITLE
Object.defineProperty clobbers an object's prototype if a getter or setter already exists

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -526,7 +526,7 @@ if (!Object.defineProperty) {
                 delete object[property];
                 object[property] = descriptor.value;
                 // Setting original `__proto__` back now.
-                object.prototype;
+                object.__proto__ = prototype;
             } else {
                 object[property] = descriptor.value;
             }


### PR DESCRIPTION
This pull request fixes a bug where Object.defineProperty would clobber an object's prototype, if it were used on a property that already had a getter or setter.
