### PR TITLE
Provide consistence for `Object.getPrototypeOf` method

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -395,7 +395,7 @@ if (!Object.getPrototypeOf) {
     // http://ejohn.org/blog/objectgetprototypeof/
     // recommended by fschaefer on github
     Object.getPrototypeOf = function getPrototypeOf(object) {
-        return object.__proto__ || object.constructor.prototype;
+        return object.constructor.prototype;
         // or undefined if not available in this engine
     };
 }


### PR DESCRIPTION
I kinda feel consistence should be most important, right?  It is definitely frustrating when its working in Chrome,Firefox, Opera,etc. but not IE .  Tracking a bug down using this function in IE could be nasty.

Ultimately your guys call, but I definitely think consistency should be over sliced browser support.
