### PR TITLE
Changed Object.isExtensible to make it, somehow, work.

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -670,8 +670,20 @@ if (!Object.isFrozen) {
 // ES5 15.2.3.13
 if (!Object.isExtensible) {
     Object.isExtensible = function isExtensible(object) {
-        return true;
-    };
+	    // 1. If Type(O) is not Object throw a TypeError exception.
+	    if ( typeof object !== object ) {
+	        throw new TypeError( );
+	    }
+	    // 2. Return the Boolean value of the [[Extensible]] internal property of O.
+	    var property = '';
+	    while ( object.hasOwnProperty( property ) ) {
+	        property += '?';
+	    }
+	    object[ property ] = true;
+	    var returnValue = object.hasOwnProperty( property );
+	    delete object[ property ];
+	    return returnValue;
+	};
 }
 
 // ES5 15.2.3.14


### PR DESCRIPTION
Changed Object.isExtensible to make it, somehow, work.

The error part is needed. And Chrome also throws an error on null whereas typeof null is undefined and I don't know which is the right behavior so I'll ask.

The second part could also simply return true except if there are some build-in object that aren't extensible. I don't know if there are so just in case, I added this dumb test.
