### PR TITLE
Object.getPrototypeOf should return undefined if object.constructor is undefined

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -436,7 +436,7 @@ if (!Object.getPrototypeOf) {
     // http://ejohn.org/blog/objectgetprototypeof/
     // recommended by fschaefer on github
     Object.getPrototypeOf = function getPrototypeOf(object) {
-        return object.__proto__ || object.constructor.prototype;
+        return object.__proto__ || (typeof object.constructor != "undefined") ? object.constructor.prototype : undefined;
         // or undefined if not available in this engine
     };
 }


### PR DESCRIPTION
This is the case with `window` in IE7, and Object.getPrototypeOf throws an exception.
