### PR TITLE
Spec links and references update

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -39,7 +39,7 @@
  * Brings an environment as close to ECMAScript 5 compliance
  * as is possible with the facilities of erstwhile engines.
  *
- * Annotated ES5: http://es5.github.com/
+ * Annotated ES5: http://es5.github.com/ (specific links below)
  * ES5 Spec: http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf
  *
  * @module
@@ -1008,6 +1008,7 @@ if (isNaN(Date.parse("2011-06-15T21:40:05+06:00"))) {
 //
 
 // ES5 15.5.4.20
+// http://es5.github.com/#x15.5.4.20
 var ws = "\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003" +
     "\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028" +
     "\u2029\uFEFF";
@@ -1027,11 +1028,13 @@ if (!String.prototype.trim || ws.trim()) {
 // ======
 //
 
+// ES5 9.4
+// http://es5.github.com/#x9.4
 // http://jsperf.com/to-integer
 var toInteger = function (n) {
     n = +n;
     if (n !== n) // isNaN
-        n = -1;
+        n = 0;
     else if (n !== 0 && n !== (1/0) && n !== -(1/0))
         n = (n > 0 || -1) * Math.floor(Math.abs(n));
     return n;
@@ -1039,6 +1042,7 @@ var toInteger = function (n) {
 
 var prepareString = "a"[0] != "a",
     // ES5 9.9
+    // http://es5.github.com/#x9.9
     toObject = function (o) {
         if (o == null) { // this matches both null and undefined
             throw new TypeError(); // TODO message


### PR DESCRIPTION
I took notice of that sad "this link is out of date" comment block at the top of the file, and went through updating the spec references and adding links to the annotated ES5.

While I was there, and reading the spec, I fixed a bug in toInteger; it should have returned 0 when given NaN instead of -1.
