### PR TITLE
Added that comment about _toString

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -177,6 +177,7 @@ var call = Function.prototype.call;
 var prototypeOfArray = Array.prototype;
 var prototypeOfObject = Object.prototype;
 var slice = prototypeOfArray.slice;
+// Having a toString local variable name breaks in Opera so use _toString.
 var _toString = call.bind(prototypeOfObject.toString);
 var owns = call.bind(prototypeOfObject.hasOwnProperty);
 


### PR DESCRIPTION
Just to clarify again toString is broken in Opera 11.5 because it has a bug with reading local variables of Object.prototype
