### PR TITLE
IE8 getOwnPropertyDescriptor

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -507,13 +507,51 @@ if (!Object.getPrototypeOf) {
 
 // ES5 15.2.3.3
 // http://es5.github.com/#x15.2.3.3
-if (!Object.getOwnPropertyDescriptor) {
+
+function doesGetOwnPropertyDescriptorWork(object) {
+    try {
+        object.sentinel = 0;
+        return Object.getOwnPropertyDescriptor(
+            object,
+            "sentinel"
+        ).value === 0;
+    } catch (exception) {
+        // returns falsy
+    }
+}
+
+// check whether getOwnPropertyDescriptor works if it's given. Otherwise,
+// shim partially.
+if (Object.defineProperty) {
+    var getOwnPropertyDescriptorWorksOnObject = 
+        doesGetOwnPropertyDescriptorWork({});
+    var getOwnPropertyDescriptorWorksOnDom = typeof document == "undefined" ||
+        doesGetOwnPropertyDescriptorWork(document.createElement("div"));
+    if (!getOwnPropertyDescriptorWorksOnDom || 
+        !getOwnPropertyDescriptorWorksOnObject
+    ) {
+        var getOwnPropertyDescriptorFallback = Object.getOwnPropertyDescriptor;
+    }
+}
+
+if (!Object.getOwnPropertyDescriptor || getOwnPropertyDescriptorFallback) {
     var ERR_NON_OBJECT = "Object.getOwnPropertyDescriptor called on a non-object: ";
 
     Object.getOwnPropertyDescriptor = function getOwnPropertyDescriptor(object, property) {
         if ((typeof object != "object" && typeof object != "function") || object === null) {
             throw new TypeError(ERR_NON_OBJECT + object);
         }
+
+        // make a valiant attempt to use the real getOwnPropertyDescriptor
+        // for I8's DOM elements.
+        if (getOwnPropertyDescriptorFallback) {
+            try {
+                return getOwnPropertyDescriptorFallback.call(Object, object, property);
+            } catch (exception) {
+                // try the shim if the real one doesn't work
+            }
+        }
+
         // If object does not owns property return undefined immediately.
         if (!owns(object, property)) {
             return;

--- a/tests/spec/s-object.js
+++ b/tests/spec/s-object.js
@@ -49,5 +49,68 @@ describe('Object', function () {
             }).toThrow(e);
         });
     });
+
+    describe("Object.getOwnPropertyDescriptor", function () {
+        function get() { return 42; }
+        function set(v) { this.val = v; }
+
+        var obj = {};
+        Object.defineProperty(obj, "normal", {
+           value: "normal"
+        });
+        Object.defineProperty(obj, "flags", {
+           value: "flags",
+           enumerable: true,
+           writable: true,
+           configurable: true
+        });
+        try {
+            Object.defineProperty(obj, "get", {
+               get: get
+            });
+            Object.defineProperty(obj, "set", {
+               set: set
+            });    
+        } catch (e) {
+            if (!e.message === "getters & setters can not be defined on this javascript engine") throw e;
+        }
+        
+
+        it('should return a property descriptor', function () {
+            var pd = Object.getOwnPropertyDescriptor(obj, "normal");
+            expect(pd.value).toBe("normal");
+            expect(pd.enumerable).toBe(false);
+            expect(pd.writable).toBe(false);
+            expect(pd.configurable).toBe(false);
+        });
+
+        it("should return true for flags", function () {
+            var pd = Object.getOwnPropertyDescriptor(obj, "flags");
+            expect(pd.value).toBe("flags");
+            expect(pd.enumerable).toBe(true);
+            expect(pd.writable).toBe(true);
+            expect(pd.configurable).toBe(true);
+        });
+
+        it("should return a getter", function () {
+            var pd = Object.getOwnPropertyDescriptor(obj, "get");
+            expect(pd.value).toBe(undefined);
+            expect(pd.get).toBe(get);
+            expect(pd.set).toBe(undefined);
+            expect(pd.enumerable).toBe(false);
+            expect(pd.writable).toBe(undefined);
+            expect(pd.configurable).toBe(false);
+        });
+
+        it("should return a setter", function (){
+            var pd = Object.getOwnPropertyDescriptor(obj, "set");
+            expect(pd.value).toBe(undefined);
+            expect(pd.get).toBe(undefined);
+            expect(pd.set).toBe(set);
+            expect(pd.writable).toBe(undefined);
+            expect(pd.configurable).toBe(false);
+            expect(pd.enumerable).toBe(false);
+        })
+    });
  
 });


### PR DESCRIPTION
IE8 defineProperty breaks because it only works on DOM elements.

getOwnPropertyDescriptor breaks for the same reasons.

This "fixes" the issue by making the getOwnPropertyDescriptor emulation slightly more correct in IE8.

This also adds unit tests for getOwnPropertyDescriptor which will fail in Opera and IE<9 because they cannot be shimmed.

 Whether we want unit tests that we cannot pass is a separate issue
