### PR TITLE
fix "defineProperty is not supported on DOM Objects" for Safari

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -718,6 +718,7 @@ if (!Object.defineProperties || definePropertiesFallback) {
         for (var property in properties) {
             if (owns(properties, property)) {
                 Object.defineProperty(object, property, properties[property]);
+			}
         }
         return object;
     };


### PR DESCRIPTION
Fix defineProperties for DOM elements as defineProperty fix
