### PR TITLE
Fixed `toObject` to work for strings in IE8 and Rhino. Added test spec for `forEach`.

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -1085,7 +1085,12 @@ var toInteger = function (n) {
     return n;
 };
 
-var prepareString = "a"[0] != "a";
+var prepareString = (function(strObj) {
+    // Check failure of by-index access of string characters (IE < 9)
+    // and failure of `0 in strObj` (Rhino)
+    return strObj[0] != "a" || !(0 in strObj);
+})(Object("a"));
+
     // ES5 9.9
     // http://es5.github.com/#x9.9
 var toObject = function (o) {
@@ -1093,8 +1098,8 @@ var toObject = function (o) {
         throw new TypeError(); // TODO message
     }
     // If the implementation doesn't support by-index access of
-    // string characters (ex. IE < 9), split the string
-    if (prepareString && typeof o == "string" && o) {
+    // string characters or `0 in stringObject`, split the string
+    if (prepareString && _toString(o) == "[object String]") {
         return o.split("");
     }
     return Object(o);

--- a/tests/spec/s-array.js
+++ b/tests/spec/s-array.js
@@ -74,6 +74,25 @@ describe('Array', function() {
             }, o);
             expect(actual).toExactlyMatch(expected);
         });
+
+        describe('strings', function() {
+            var str = 'Hello, World!';
+            it('should iterate all in a string', function() {
+                actual = [];
+                Array.prototype.forEach.call(str, function(item, index) {
+                    actual[index] = item;
+                });
+                expect(actual).toExactlyMatch(str.split(''));
+            });
+            it('should iterate all in a string using a context', function() {
+                actual = [];
+                var o = { a: actual };
+                Array.prototype.forEach.call(str, function(item, index) {
+                    this.a[index] = item;
+                }, o);
+                expect(actual).toExactlyMatch(str.split(''));
+            });
+        });
     });
     describe('some', function() {
         var actual, expected, numberOfRuns;


### PR DESCRIPTION
Fixes #90.
