### PR TITLE
Fixes npm WARN

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     ],
     "bugs": {
         "mail": "kris@cixar.com",
-        "web": "http://github.com/kriskowal/es5-shim/issues"
+        "url": "http://github.com/kriskowal/es5-shim/issues"
     },
     "licenses": [
         {


### PR DESCRIPTION
Fixes npm warning about mislabeled bugs['web'] by renaming web to url.
