### PR TITLE
indexOf doesn't work with undefined in ie8

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -508,7 +508,7 @@ if (!Array.prototype.lastIndexOf || ([0, 1].lastIndexOf(0, -3) != -1)) {
         // handle negative indices
         i = i >= 0 ? i : length - Math.abs(i);
         for (; i >= 0; i--) {
-            if (i in self && sought === self[i]) {
+            if (sought === self[i]) {
                 return i;
             }
         }


### PR DESCRIPTION
The check in line 511 breaks the behaviour of indexOf in ie8.

Test case: `[undefined].indexOf(undefined)`
Expected: return `0`
Actual: return `-1`

The reason for this is because in ie8

`0 in [undefined]`

returns false, whereas in more modern browsers it returns true.

I'm not sure why this check was being done in the first place and think it may not be required (hence my proposed change).  If it is required, can we find a way to achieve the same thing without breaking ie8?
