### PR TITLE
add typeof check for document so can be used outside of browser

### DIFF
--- a/es5-sham.js
+++ b/es5-sham.js
@@ -100,7 +100,7 @@ if (!Object.create) {
     // Contributed by Brandon Benvie, October, 2012
     var createEmpty;
     var supportsProto = Object.prototype.__proto__ === null;
-    if (supportsProto) {
+    if (supportsProto || typeof document == 'undefined') {
         createEmpty = function () {
             return { "__proto__": null };
         };


### PR DESCRIPTION
The Object.create trick works great for browsers that don't support **proto** but if we want to use this library _outside_ the browser in an environment like [Windows Script Host](http://en.wikipedia.org/wiki/Windows_Script_Host) we can't use document.
