### PR TITLE
Make component.json compatible with bower and component(1).

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,29 +1,9 @@
 {
     "name": "es5-shim",
-    "version": "2.0.5",
+    "repo": "kriskowal/es5-shim",
     "description": "ES5 as implementable on previous engines",
-    "homepage": "http://github.com/kriskowal/es5-shim/",
-    "contributors": [
-        "Kris Kowal <kris@cixar.com> (http://github.com/kriskowal/)",
-        "Sami Samhuri <sami.samhuri@gmail.com> (http://samhuri.net/)",
-        "Florian Schäfer <florian.schaefer@gmail.com> (http://github.com/fschaefer)",
-        "Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)",
-        "Kit Cambridge <kitcambridge@gmail.com> (http://kitcambridge.github.com)"
-    ],
-    "bugs": {
-        "mail": "kris@cixar.com",
-        "url": "http://github.com/kriskowal/es5-shim/issues"
-    },
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "http://github.com/kriskowal/es5-shim/raw/master/LICENSE"
-        }
-    ],
+    "version": "2.0.5",
     "main": "es5-shim.js",
     "scripts": ["es5-shim.js"],
-    "repo": "kriskowal/es5-shim",
-    "engines": {
-        "node": ">=0.2.0"
-    }
+    "license": "MIT"
 }


### PR DESCRIPTION
Symlinking component.json to package.json breaks [component(1)](https://github.com/component/component). Changed to make it a real file that is compatible with both [bower](https://github.com/twitter/bower) and component(1):

`bower install es5-shim`

`component install kriskowal/es5-shim`
