### PR TITLE
Component.json declaration

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,9 @@
+{
+  "name": "es5-shim",
+  "version": "2.0.8",
+  "main": "./es5-shim.js",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/kriskowal/es5-shim"
+  }
+}


### PR DESCRIPTION
Currently, after installing es5-shim with bower the listing of sources is empty due to a missing main in the generated component.json

```
bower install es5-shim
bower list --sources
{}
```

I am attaching a json conf including the non minified es5-shim.
Let me know what you think and if this is useful.
Regards.
Pablo
