### PR TITLE
Adding Steven Levithan's String.prototype.split for RegExp

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,4 +22,4 @@
 -   lexer Alexey Zakharov XXX TODO License or CLA
 -   280 North Inc. (Now Motorola LLC, a subsidiary of Google Inc.)
     Copyright (C) 2009 MIT License
-
+-   Steven Levithan Copyright (C) 2012 MIT License

--- a/es5-shim.js
+++ b/es5-shim.js
@@ -1105,6 +1105,100 @@ if("0".split(void 0, 0).length) {
     }
 }
 
+// ES5 15.5.4.14
+// http://es5.github.com/#x15.5.4.14
+// [bugfix, IE lt 9, firefox 4, Konqueror, Opera, obscure browsers]
+// Many browsers do not split properly with regular expressions or they
+// do not perform the split correctly under obscure conditions.
+// See http://blog.stevenlevithan.com/archives/cross-browser-split
+// I've tested in many browsers and this seems to cover the deviant ones:
+//    'ab'.split(/(?:ab)*/) should be ["", ""], not [""]
+//    '.'.split(/(.?)(.?)/) should be ["", ".", "", ""], not ["", ""]
+//    'tesst'.split(/(s)*/) should be ["t", undefined, "e", "s", "t"], not
+//       [undefined, "t", undefined, "e", ...]
+//    ''.split(/.?/) should be [], not [""]
+//    '.'.split(/()()/) should be ["."], not ["", "", "."]
+
+if ('ab'.split(/(?:ab)*/).length !== 2 || 
+	'.'.split(/(.?)(.?)/).length !== 4 ||
+	'tesst'.split(/(s)*/)[1] === "t" ||
+	''.split(/.?/).length === 0 ||
+	'.'.split(/()()/).length > 1) {
+	(function (undef) {
+    var nativeSplit = String.prototype.split,
+        compliantExecNpcg = /()??/.exec("")[1] === undef; // NPCG: nonparticipating capturing group
+
+		String.prototype.split = function (str, separator, limit) {
+			// If `separator` is not a regex, use `nativeSplit`
+			if (Object.prototype.toString.call(separator) !== "[object RegExp]") {
+				return nativeSplit.apply(this, arguments);
+			}
+
+			var output = [],
+				flags = (separator.ignoreCase ? "i" : "") +
+						(separator.multiline  ? "m" : "") +
+						(separator.extended   ? "x" : "") + // Proposed for ES6
+						(separator.sticky     ? "y" : ""), // Firefox 3+
+				lastLastIndex = 0,
+				// Make `global` and avoid `lastIndex` issues by working with a copy
+				separator = new RegExp(separator.source, flags + "g"),
+				separator2, match, lastIndex, lastLength;
+			str += ""; // Type-convert
+			if (!compliantExecNpcg) {
+				// Doesn't need flags gy, but they don't hurt
+				separator2 = new RegExp("^" + separator.source + "$(?!\\s)", flags);
+			}
+			/* Values for `limit`, per the spec:
+			 * If undefined: 4294967295 // Math.pow(2, 32) - 1
+			 * If 0, Infinity, or NaN: 0
+			 * If positive number: limit = Math.floor(limit); if (limit > 4294967295) limit -= 4294967296;
+			 * If negative number: 4294967296 - Math.floor(Math.abs(limit))
+			 * If other: Type-convert, then use the above rules
+			 */
+			limit = limit === undef ?
+				-1 >>> 0 : // Math.pow(2, 32) - 1
+				limit >>> 0; // ToUint32(limit)
+			while (match = separator.exec(str)) {
+				// `separator.lastIndex` is not reliable cross-browser
+				lastIndex = match.index + match[0].length;
+				if (lastIndex > lastLastIndex) {
+					output.push(str.slice(lastLastIndex, match.index));
+					// Fix browsers whose `exec` methods don't consistently return `undefined` for
+					// nonparticipating capturing groups
+					if (!compliantExecNpcg && match.length > 1) {
+						match[0].replace(separator2, function () {
+							for (var i = 1; i < arguments.length - 2; i++) {
+								if (arguments[i] === undef) {
+									match[i] = undef;
+								}
+							}
+						});
+					}
+					if (match.length > 1 && match.index < str.length) {
+						Array.prototype.push.apply(output, match.slice(1));
+					}
+					lastLength = match[0].length;
+					lastLastIndex = lastIndex;
+					if (output.length >= limit) {
+						break;
+					}
+				}
+				if (separator.lastIndex === match.index) {
+					separator.lastIndex++; // Avoid an infinite loop
+				}
+			}
+			if (lastLastIndex === str.length) {
+				if (lastLength || !separator.test("")) {
+					output.push("");
+				}
+			} else {
+				output.push(str.slice(lastLastIndex));
+			}
+			return output.length > limit ? output.slice(0, limit) : output;
+		};
+	}());
+}
+
 // ECMA-262, 3rd B.2.3
 // Note an ECMAScript standart, although ECMAScript 3rd Edition has a
 // non-normative section suggesting uniform semantics and it should be

--- a/tests/spec/s-string.js
+++ b/tests/spec/s-string.js
@@ -20,5 +20,185 @@ describe('String', function() {
         it('If "separator" is undefined and "limit" set to 0 must return Array[]', function() {
             expect(test.split(void 0, 0)).toEqual([]);
         });
+
+		describe('Tests from Steven Levithan', function () {
+			it("''.split() results in ['']", function () {
+				expect(''.split()).toEqual(['']);
+			});
+			it("''.split(/./) results in ['']", function () {
+				expect(''.split(/./)).toEqual(['']);
+			});
+			it("''.split(/.?/) results in []", function () {
+				expect(''.split(/.?/)).toEqual([]);
+			});
+			it("''.split(/.??/) results in []", function () {
+				expect(''.split(/.??/)).toEqual([]);
+			});
+			it("'ab'.split(/a*/) results in ['', 'b']", function () {
+				expect('ab'.split(/a*/)).toEqual(['', 'b']);
+			});
+			it("'ab'.split(/a*?/) results in ['a', 'b']", function () {
+				expect('ab'.split(/a*?/)).toEqual(['a', 'b']);
+			});
+			it("'ab'.split(/(?:ab)/) results in ['', '']", function () {
+				expect('ab'.split(/(?:ab)/)).toEqual(['', '']);
+			});
+			it("'ab'.split(/(?:ab)*/) results in ['', '']", function () {
+				expect('ab'.split(/(?:ab)*/)).toEqual(['', '']);
+			});
+			it("'ab'.split(/(?:ab)*?/) results in ['a', 'b']", function () {
+				expect('ab'.split(/(?:ab)*?/)).toEqual(['a', 'b']);
+			});
+			it("'test'.split('') results in ['t', 'e', 's', 't']", function () {
+				expect('test'.split('')).toEqual(['t', 'e', 's', 't']);
+			});
+			it("'test'.split() results in ['test']", function () {
+				expect('test'.split()).toEqual(['test']);
+			});
+			it("'111'.split(1) results in ['', '', '', '']", function () {
+				expect('111'.split(1)).toEqual(['', '', '', '']);
+			});
+			it("'test'.split(/(?:)/, 2) results in ['t', 'e']", function () {
+				expect('test'.split(/(?:)/, 2)).toEqual(['t', 'e']);
+			});
+			it("'test'.split(/(?:)/, -1) results in ['t', 'e', 's', 't']", function () {
+				expect('test'.split(/(?:)/, -1)).toEqual(['t', 'e', 's', 't']);
+			});
+			it("'test'.split(/(?:)/, undefined) results in ['t', 'e', 's', 't']", function () {
+				expect('test'.split(/(?:)/, undefined)).toEqual(['t', 'e', 's', 't']);
+			});
+			it("'test'.split(/(?:)/, null) results in []", function () {
+				expect('test'.split(/(?:)/, null)).toEqual([]);
+			});
+			it("'test'.split(/(?:)/, NaN) results in []", function () {
+				expect('test'.split(/(?:)/, NaN)).toEqual([]);
+			});
+			it("'test'.split(/(?:)/, true) results in ['t']", function () {
+				expect('test'.split(/(?:)/, true)).toEqual(['t']);
+			});
+			it("'test'.split(/(?:)/, '2') results in ['t', 'e']", function () {
+				expect('test'.split(/(?:)/, '2')).toEqual(['t', 'e']);
+			});
+			it("'test'.split(/(?:)/, 'two') results in []", function () {
+				expect('test'.split(/(?:)/, 'two')).toEqual([]);
+			});
+			it("'a'.split(/-/) results in ['a']", function () {
+				expect('a'.split(/-/)).toEqual(['a']);
+			});
+			it("'a'.split(/-?/) results in ['a']", function () {
+				expect('a'.split(/-?/)).toEqual(['a']);
+			});
+			it("'a'.split(/-??/) results in ['a']", function () {
+				expect('a'.split(/-??/)).toEqual(['a']);
+			});
+			it("'a'.split(/a/) results in ['', '']", function () {
+				expect('a'.split(/a/)).toEqual(['', '']);
+			});
+			it("'a'.split(/a?/) results in ['', '']", function () {
+				expect('a'.split(/a?/)).toEqual(['', '']);
+			});
+			it("'a'.split(/a??/) results in ['a']", function () {
+				expect('a'.split(/a??/)).toEqual(['a']);
+			});
+			it("'ab'.split(/-/) results in ['ab']", function () {
+				expect('ab'.split(/-/)).toEqual(['ab']);
+			});
+			it("'ab'.split(/-?/) results in ['a', 'b']", function () {
+				expect('ab'.split(/-?/)).toEqual(['a', 'b']);
+			});
+			it("'ab'.split(/-??/) results in ['a', 'b']", function () {
+				expect('ab'.split(/-??/)).toEqual(['a', 'b']);
+			});
+			it("'a-b'.split(/-/) results in ['a', 'b']", function () {
+				expect('a-b'.split(/-/)).toEqual(['a', 'b']);
+			});
+			it("'a-b'.split(/-?/) results in ['a', 'b']", function () {
+				expect('a-b'.split(/-?/)).toEqual(['a', 'b']);
+			});
+			it("'a-b'.split(/-??/) results in ['a', '-', 'b']", function () {
+				expect('a-b'.split(/-??/)).toEqual(['a', '-', 'b']);
+			});
+			it("'a--b'.split(/-/) results in ['a', '', 'b']", function () {
+				expect('a--b'.split(/-/)).toEqual(['a', '', 'b']);
+			});
+			it("'a--b'.split(/-?/) results in ['a', '', 'b']", function () {
+				expect('a--b'.split(/-?/)).toEqual(['a', '', 'b']);
+			});
+			it("'a--b'.split(/-??/) results in ['a', '-', '-', 'b']", function () {
+				expect('a--b'.split(/-??/)).toEqual(['a', '-', '-', 'b']);
+			});
+			it("''.split(/()()/) results in []", function () {
+				expect(''.split(/()()/)).toEqual([]);
+			});
+			it("'.'.split(/()()/) results in ['.']", function () {
+				expect('.'.split(/()()/)).toEqual(['.']);
+			});
+			it("'.'.split(/(.?)(.?)/) results in ['', '.', '', '']", function () {
+				expect('.'.split(/(.?)(.?)/)).toEqual(['', '.', '', '']);
+			});
+			it("'.'.split(/(.??)(.??)/) results in ['.']", function () {
+				expect('.'.split(/(.??)(.??)/)).toEqual(['.']);
+			});
+			it("'.'.split(/(.)?(.)?/) results in ['', '.', undefined, '']", function () {
+				expect('.'.split(/(.)?(.)?/)).toEqual(['', '.', undefined, '']);
+			});
+			it("'A<B>bold</B>and<CODE>coded</CODE>'.split(/<(\\/)?([^<>]+)>/) results in ['A', undefined, 'B', 'bold', '/', 'B', 'and', undefined, 'CODE', 'coded', '/', 'CODE', '']", function () {
+				expect('A<B>bold</B>and<CODE>coded</CODE>'.split(/<(\/)?([^<>]+)>/)).toEqual(['A', undefined, 'B', 'bold', '/', 'B', 'and', undefined, 'CODE', 'coded', '/', 'CODE', '']);
+			});
+			it("'tesst'.split(/(s)*/) results in ['t', undefined, 'e', 's', 't']", function () {
+				expect('tesst'.split(/(s)*/)).toEqual(['t', undefined, 'e', 's', 't']);
+			});
+			it("'tesst'.split(/(s)*?/) results in ['t', undefined, 'e', undefined, 's', undefined, 's', undefined, 't']", function () {
+				expect('tesst'.split(/(s)*?/)).toEqual(['t', undefined, 'e', undefined, 's', undefined, 's', undefined, 't']);
+			});
+			it("'tesst'.split(/(s*)/) results in ['t', '', 'e', 'ss', 't']", function () {
+				expect('tesst'.split(/(s*)/)).toEqual(['t', '', 'e', 'ss', 't']);
+			});
+			it("'tesst'.split(/(s*?)/) results in ['t', '', 'e', '', 's', '', 's', '', 't']", function () {
+				expect('tesst'.split(/(s*?)/)).toEqual(['t', '', 'e', '', 's', '', 's', '', 't']);
+			});
+			it("'tesst'.split(/(?:s)*/) results in ['t', 'e', 't']", function () {
+				expect('tesst'.split(/(?:s)*/)).toEqual(['t', 'e', 't']);
+			});
+			it("'tesst'.split(/(?=s+)/) results in ['te', 's', 'st']", function () {
+				expect('tesst'.split(/(?=s+)/)).toEqual(['te', 's', 'st']);
+			});
+			it("'test'.split('t') results in ['', 'es', '']", function () {
+				expect('test'.split('t')).toEqual(['', 'es', '']);
+			});
+			it("'test'.split('es') results in ['t', 't']", function () {
+				expect('test'.split('es')).toEqual(['t', 't']);
+			});
+			it("'test'.split(/t/) results in ['', 'es', '']", function () {
+				expect('test'.split(/t/)).toEqual(['', 'es', '']);
+			});
+			it("'test'.split(/es/) results in ['t', 't']", function () {
+				expect('test'.split(/es/)).toEqual(['t', 't']);
+			});
+			it("'test'.split(/(t)/) results in ['', 't', 'es', 't', '']", function () {
+				expect('test'.split(/(t)/)).toEqual(['', 't', 'es', 't', '']);
+			});
+			it("'test'.split(/(es)/) results in ['t', 'es', 't']", function () {
+				expect('test'.split(/(es)/)).toEqual(['t', 'es', 't']);
+			});
+			it("'test'.split(/(t)(e)(s)(t)/) results in ['', 't', 'e', 's', 't', '']", function () {
+				expect('test'.split(/(t)(e)(s)(t)/)).toEqual(['', 't', 'e', 's', 't', '']);
+			});
+			it("'.'.split(/(((.((.??)))))/) results in ['', '.', '.', '.', '', '', '']", function () {
+				expect('.'.split(/(((.((.??)))))/)).toEqual(['', '.', '.', '.', '', '', '']);
+			});
+			it("'.'.split(/(((((.??)))))/) results in ['.']", function () {
+				expect('.'.split(/(((((.??)))))/)).toEqual(['.']);
+			});
+			it("'a b c d'.split(/ /, -(Math.pow(2, 32) - 1)) results in ['a']", function () {
+				expect('a b c d'.split(/ /, -(Math.pow(2, 32) - 1))).toEqual(['a']);
+			});
+			it("'a b c d'.split(/ /, Math.pow(2, 32) + 1) results in ['a']", function () {
+				expect('a b c d'.split(/ /, Math.pow(2, 32) + 1)).toEqual(['a']);
+			});
+			it("'a b c d'.split(/ /, Infinity) results in []", function () {
+				expect('a b c d'.split(/ /, Infinity)).toEqual([]);
+			});
+		});
     });
 });


### PR DESCRIPTION
I asked and received his blessing:

> Tyler, thanks for offering to take this up! I’d be more than happy to see my code for this shared more broadly, and/or improved. My split shim and tests are MIT licensed, like es5 shim. By the way, Kris (author of es5-shim) brought this up before, but no one has done the work to see this through, like you’ve offered to do. See https://github.com/kriskowal/es5 shim/issues/103
> 
> /Steven

This also closes issue #103

Please let me know if there is anything I should do to change the code to follow some style guidelines.  I didn't see anything published anywhere, but I'll happily take feedback.
