### PR TITLE
fixes #174: Array.splice fails on IE8 if `this` is of type Arguments

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -191,6 +191,8 @@ if ((supportsAccessors = owns(prototypeOfObject, "__defineGetter__"))) {
 // IE < 9 bug: [1,2].splice(0).join("") == "" but should be "12"
 if ([1,2].splice(0).length != 2) {
     var array_splice = Array.prototype.splice;
+    var array_push = Array.prototype.push;
+    var array_unshift = Array.prototype.unshift;
 
     if (function() { // test IE < 9 to splice bug - see issue #138
         function makeArray(l) {
@@ -250,12 +252,12 @@ if ([1,2].splice(0).length != 2) {
             if (addElementsCount > 0) {
                 if (deleteCount <= 0) {
                     if (start == this.length) { // tiny optimisation #1
-                        this.push.apply(this, args);
+                        array_push.apply(this, args);
                         return [];
                     }
 
                     if (start == 0) { // tiny optimisation #2
-                        this.unshift.apply(this, args);
+                        array_unshift.apply(this, args);
                         return [];
                     }
                 }

--- a/tests/spec/s-array.js
+++ b/tests/spec/s-array.js
@@ -1217,6 +1217,28 @@ describe('Array', function() {
         it('runshould have the right length', function () {
             expect(test.splice.length).toBe(2);
         });
+
+        it('should work with objects - adding 1', function () {
+            var obj = {};
+            test.splice.call(obj, 0, 0, 1, 2, 3);
+            expect(obj.length).toEqual(3);
+        });
+        it('should work with objects - adding 2', function () {
+            var obj = {0:1, length: 1};
+            test.splice.call(obj, 1, 0, 2, 3);
+            expect(obj.length).toEqual(3);
+        });
+        it('should work with objects - removing', function () {
+            var obj = {0:1, 1:2, 2: 3, length: 3};
+            test.splice.call(obj, 0, 3);
+            expect(obj.length).toEqual(0);
+        });
+        it('should work with objects - replacing', function () {
+            var obj = {0:99, length: 1};
+            test.splice.call(obj, 0, 1, 1, 2, 3);
+            expect(obj.length).toEqual(3);
+            expect(obj[0]).toEqual(1);
+        });
     });
 
 


### PR DESCRIPTION
- tests
