### PR TITLE
Enforce correct ES5 parseInt behavior, with tests.

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -32,7 +32,7 @@ if (parseInt('08') !== 8) {
         var hexRegex = /^0[xX]/;
         return function parseIntES5(str, radix) {
             str = String(str).trim();
-            if (!radix) {
+            if (!+radix) {
                 radix = hexRegex.test(str) ? 16 : 10;
             }
             return origParseInt(str, radix);

--- a/tests/spec/s-global.js
+++ b/tests/spec/s-global.js
@@ -29,6 +29,12 @@ describe('global methods', function () {
             expect(parseInt('  42')).toBe(parseInt('42', 10));
             expect(parseInt('  08')).toBe(parseInt('08', 10));
         });
+
+       it('defaults the radix properly when not a true number', function () {
+           var fakeZero = { valueOf: function () { return 0; } };
+           expect(parseInt('08', fakeZero)).toBe(parseInt('08', 10));
+           expect(parseInt('0x16', fakeZero)).toBe(parseInt('0x16', 16));
+       });
     });
 });
 


### PR DESCRIPTION
Fixes #193
