### PR TITLE
Only shim when Date.parse is absent or can't handle ISO dates

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -829,7 +829,7 @@ if (!dateToJSONIsSupported) {
 // http://es5.github.com/#x15.9.4.2
 // based on work shared by Daniel Friesen (dantman)
 // http://gist.github.com/303249
-if (!Date.parse || "Date.parse is buggy") {
+if (!Date.parse || isNaN(Date.parse("2000-01-01T00:00:00.000Z"))) {
     // XXX global assignment won't work in embeddings that use
     // an alternate object for the context.
     Date = (function(NativeDate) {


### PR DESCRIPTION
Fixes #203
