### PR TITLE
Opera Mini false positive on `__proto__` check. Using a more reliable check here.

### DIFF
--- a/es5-sham.js
+++ b/es5-sham.js
@@ -163,7 +163,10 @@ if (!Object.create) {
 
     // Contributed by Brandon Benvie, October, 2012
     var createEmpty;
-    var supportsProto = Object.prototype.__proto__ === null;
+    var supportsProto = !({__proto__:null} instanceof Object);
+                        // the following produces false positives
+                        // in Opera Mini => not a reliable check
+                        // Object.prototype.__proto__ === null
     if (supportsProto || typeof document == 'undefined') {
         createEmpty = function () {
             return { "__proto__": null };


### PR DESCRIPTION
`__proto__` might be there for various reason, Opera Mini fails to `Object.create(null)` if you don't check `__proto__` for real, which is not just by verifying the chain ;-)
