### PR TITLE
Opera Mini infinite loop caused by weak `Object.getPrototypeOf` logic

### DIFF
--- a/es5-sham.js
+++ b/es5-sham.js
@@ -52,7 +52,7 @@ if (!Object.getPrototypeOf) {
     // ... Opera Mini breaks here with infinite loops
     Object.getPrototypeOf = function getPrototypeOf(object) {
         var proto = object.__proto__;
-        return (proto || proto === null && proto) || (
+        return (proto || ((proto === null) && proto)) || (
             object.constructor
                 ? object.constructor.prototype
                 : prototypeOfObject


### PR DESCRIPTION
once again, Opera Mini supports `__proto__` but not `Object.getPrototypeOf` which means how it was would easily fall into infinite recursion.

As extra note, I would recommend to put your tests online so you can directly verify in there.
Jasmine locally is not a good option since Opera Mini as other server side based browsers will not be able to access your intranet.

Best Regards
