### PR TITLE
Accessors work fine in IE8.

### DIFF
--- a/es5-sham.js
+++ b/es5-sham.js
@@ -36,7 +36,21 @@ var defineSetter;
 var lookupGetter;
 var lookupSetter;
 var supportsAccessors;
-if ((supportsAccessors = owns(prototypeOfObject, "__defineGetter__"))) {
+(function() {
+    supportsAccessors = false;
+    try {
+        var obj = document.createElement("div");
+        Object.defineProperty(obj, "dummy", {
+            get: function() {
+                return "test";
+            }
+        });
+        if (obj.dummy === "test")
+            supportsAccessors = true;
+    }
+    catch (e) {}
+}());
+if (supportsAccessors) {
     defineGetter = call.bind(prototypeOfObject.__defineGetter__);
     defineSetter = call.bind(prototypeOfObject.__defineSetter__);
     lookupGetter = call.bind(prototypeOfObject.__lookupGetter__);


### PR DESCRIPTION
Is there a reason we're not checking accessor support directly? IE8 does support property accessors as long as the given the object is a DOM element. http://msdn.microsoft.com/en-us/library/dd548687(VS.85).aspx
