### PR TITLE
Use current offset instead of offset in 1970 year

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -889,8 +889,9 @@ if (!Date.parse || doesNotParseY2KNewYear || acceptsInvalidDates || !supportsExt
             );
         }
 
+        var localOffset = (new NativeDate).getTimezoneOffset() * 60 * 1000; 
         function toUTC(t) {
-            return Number(new NativeDate(1970, 0, 1, 0, 0, 0, t));
+            return t + localOffset;
         }
 
         // Copy any custom methods a 3rd party library may have added


### PR DESCRIPTION
IE and may be safari on mac
Moscow (+4h now)

Before:
new Date( '2014-01-01T00:00:00' ) -> Wed Jan 01 2014 01:00:00 GMT+0400 

After:
new Date( '2014-01-01T00:00:00' ) -> Wed Jan 01 2014 00:00:00 GMT+0400 
