### PR TITLE
Use an internal defineProperties helper to make properties non-enumerable where possible

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -350,8 +350,8 @@ var spliceNoopReturnsEmptyArray = (function () {
     var result = a.splice();
     return a.length === 2 && isArray(result) && result.length === 0;
 }());
-// Safari 5.0 bug where .split() returns undefined
 defineProperties(ArrayPrototype, {
+    // Safari 5.0 bug where .splice() returns undefined
     splice: function splice(start, deleteCount) {
         if (arguments.length === 0) {
             return [];


### PR DESCRIPTION
Fixes #83.
