### PR TITLE
add sham.js has Function.prototype.bind method

### DIFF
--- a/es5-sham.js
+++ b/es5-sham.js
@@ -26,6 +26,24 @@
   }
 }(this, function () {
 
+if (!Function.prototype.bind) {
+    Function.prototype.bind = Function.prototype.bind || function(b) {
+        if (typeof this !== "function") {
+            throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+        }
+        var a = Array.prototype.slice,
+            f = a.call(arguments, 1),
+            e = this,
+            c = function() {},
+            d = function() {
+                return e.apply(this instanceof c ? this : b || window, f.concat(a.call(arguments)));
+            };
+        c.prototype = this.prototype;
+        d.prototype = new c();
+        return d;
+    };
+}
+
 var call = Function.prototype.call;
 var prototypeOfObject = Object.prototype;
 var owns = call.bind(prototypeOfObject.hasOwnProperty);


### PR DESCRIPTION
`es5-shim` is conflict with Ember, so we'd better add native bind method to `es5-sham`, then we have no need depend on `es5-shim`, then we can use `es5-sham`  directly in ember-cli project.
