### PR TITLE
Prevent crash in ie8

### DIFF
--- a/es5-sham.js
+++ b/es5-sham.js
@@ -245,7 +245,7 @@ if (!Object.create) {
             object.__proto__ = prototype;
         }
 
-        if (properties !== void 0) {
+        if (properties !== undefined) {
             Object.defineProperties(object, properties);
         }
 


### PR DESCRIPTION
So it turns out that using 'void 0' causes ie8 to crash. As 'undefined' is identical this PR just swaps that in instead.

FYI, this is what was causing https://github.com/es-shims/es5-shim/issues/264. 
