### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,13 @@
     "javascript",
     "ecmascript",
     "polyfill"
-  ]
+  ],
+  "spm": {
+    "main": "es5-shim.js",
+    "output": [
+      "es5-sham.js"
+    ],
+    "buildArgs": "--include standalone"
+  }
 }
 


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/es5-shim

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of es5-shim in spmjs, I can add it for your account after signing in http://spmjs.io.
