### PR TITLE
Incorrect check for a non-compliant Array.prototype.splice implementation

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -348,7 +348,7 @@ defineProperties(ArrayPrototype, {
             return array_splice.apply(this, arguments);
         }
     }
-}, spliceNoopReturnsEmptyArray);
+}, !spliceNoopReturnsEmptyArray);
 
 var spliceWorksWithEmptyObject = (function () {
     var obj = {};


### PR DESCRIPTION
Fixed a check for a non-compliant Array.prototype.splice implementation that was causing a shim to be applied to ES5-compliant browsers instead of applying it to buggy/incorrectly implemented ones
