### PR TITLE
fixed issue #242

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -726,7 +726,7 @@ defineProperties(ArrayPrototype, {
 // http://whattheheadsaid.com/2010/10/a-safer-object-keys-compatibility-implementation
 var hasDontEnumBug = !({'toString': null}).propertyIsEnumerable('toString'),
     hasProtoEnumBug = function () {}.propertyIsEnumerable('prototype'),
-    hasStringEnumBug = !'x'.propertyIsEnumerable('0'),
+    hasStringEnumBug = !owns('x', '0'),
     dontEnums = [
         'toString',
         'toLocaleString',


### PR DESCRIPTION
- issue #242: Object.keys shim does not work with boxed primitives with extra properties.
- update test case in `s-object.js': enumerating over non-enumerable properties.

And I have a question about the test cases I have modified. 

I am not very clear why the `prototype` s are used instead of the instance object. Apparently on legacy browsers which `Object.defineProperty` is not supported, shim functions are directly added to the prototypes. And it will cause the test cases to fail. Would it be better to test against the blank objects? 

Thanks.
