### PR TITLE
Do not add `__proto__` to return value of `Object.create(null)`.

### DIFF
--- a/es5-sham.js
+++ b/es5-sham.js
@@ -274,9 +274,6 @@ if (!Object.create) {
             delete empty.toLocaleString;
             delete empty.toString;
             delete empty.valueOf;
-            /* eslint-disable no-proto */
-            empty.__proto__ = null;
-            /* eslint-enable no-proto */
 
             var Empty = function Empty() {};
             Empty.prototype = empty;


### PR DESCRIPTION
Conversation behind this change: https://twitter.com/bterlson/status/558023598095360000
Before this change `Object.create(null)` and iterating the returned object, via `Object.keys`,
in IE8 would result in `__proto__` incorrectly being returned as an own key.