### PR TITLE
Update es5-shim.js String.prototype.trim()

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -1402,17 +1402,18 @@ var ws = '\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003' +
     '\u2029\uFEFF';
 var zeroWidth = '\u200b';
 var wsRegexChars = '[' + ws + ']';
-var trimBeginRegexp = new RegExp('^' + wsRegexChars + wsRegexChars + '*');
-var trimEndRegexp = new RegExp(wsRegexChars + wsRegexChars + '*$');
+var rtrim = new RegExp('^' + wsRegexChars + '+|' + wsRegexChars + '+$', 'g');
 var hasTrimWhitespaceBug = StringPrototype.trim && (ws.trim() || !zeroWidth.trim());
 defineProperties(StringPrototype, {
     // http://blog.stevenlevithan.com/archives/faster-trim-javascript
     // http://perfectionkills.com/whitespace-deviations/
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim
     trim: function trim() {
+        // Make sure we trim BOM and NBSP
         if (typeof this === 'undefined' || this === null) {
             throw new TypeError("can't convert " + this + ' to object');
         }
-        return String(this).replace(trimBeginRegexp, '').replace(trimEndRegexp, '');
+        return String(this).replace(rtrim, '');
     }
 }, hasTrimWhitespaceBug);
 


### PR DESCRIPTION
improve string.trim()
according to:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim
http://stackoverflow.com/questions/2308134/trim-in-javascript-not-working-in-ie/29001502#29001502