### PR TITLE
User `files` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
       "url": "http://github.com/es-shims/es5-shim/raw/master/LICENSE"
     }
   ],
+  "files": [
+    "es5-shim.js",
+    "es5-sham.js"
+  ],
   "main": "es5-shim.js",
   "repository": {
     "type": "git",
@@ -71,4 +75,3 @@
     "polyfill"
   ]
 }
-


### PR DESCRIPTION
This is to avoid installing a whole bunch of unneeded files when installing from `npm`.
Diff:

![image](https://cloud.githubusercontent.com/assets/1404810/7091204/7d2365b8-dfa8-11e4-9863-42f12ef216ee.png)
