### PR TITLE
IE8 - Fix #252 'constructor' in Object.defineProperties

### DIFF
--- a/es5-sham.js
+++ b/es5-sham.js
@@ -386,11 +386,11 @@ if (!Object.defineProperties || definePropertiesFallback) {
             }
         }
 
-        for (var property in properties) {
-            if (owns(properties, property) && property !== '__proto__') {
+        Object.keys(properties).forEach(function (property) {
+            if (property !== '__proto__') {
                 Object.defineProperty(object, property, properties[property]);
             }
-        }
+        });
         return object;
     };
 }

--- a/tests/spec/s-object.js
+++ b/tests/spec/s-object.js
@@ -233,4 +233,17 @@ describe('Object', function () {
             }
         });
     });
+
+    describe('Object.defineProperties', function () {
+        it('should define the constructor property', function () {
+            var target = {};
+            var newProperties = {
+                constructor: {
+                  value: 'new constructor'
+                }
+            };
+            Object.defineProperties(target, newProperties);
+            expect(target.constructor).toEqual('new constructor');
+        });
+    });
 });


### PR DESCRIPTION
Fix #252 

In IE8 the 'constructor' property was not being defined by the Object.defineProperties method of the sham because IE8 does not enumerate the constructor property.

I've tested this change manually against IE8 running on Windows XP, but I wasn't able to work out how you do your automated cross browser testing.