### PR TITLE
Avoid publish dev file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.travis.yml
+/tests
+Makefile


### PR DESCRIPTION
adding `.npmignore` to avoid publish dev files to npm