### PR TITLE
fix define empty descriptor

### DIFF
--- a/es5-sham.js
+++ b/es5-sham.js
@@ -413,7 +413,7 @@ if (!Object.defineProperty || definePropertyFallback) {
                 object[property] = descriptor.value;
             }
         } else {
-            if (!supportsAccessors) {
+            if (!supportsAccessors && (('get' in descriptor) || ('set' in descriptor))) {
                 throw new TypeError(ERR_ACCESSORS_NOT_SUPPORTED);
             }
             // If we got that far then getters and setters can be defined !!

--- a/tests/spec/s-object.js
+++ b/tests/spec/s-object.js
@@ -180,6 +180,12 @@ describe('Object', function () {
                 Object.defineProperty(42, 'name', {});
             }).toThrow();
         });
+
+        it('should not throw error for empty descriptor', function () {
+            expect(function () {
+                Object.defineProperty({}, 'name', {});
+            }).not.toThrow();
+        });
     });
 
     describe('Object.getOwnPropertyDescriptor', function () {


### PR DESCRIPTION
It should not throw error for empty descriptor

```js
Object.defineProperty({},'a',{});
```

It is used in intl:  https://github.com/andyearnshaw/Intl.js/blob/1fced3d60d004b9a853e3699cc6f3329096957da/src/core.js#L119