### PR TITLE
Fix Object.create sham to not set __proto__

### DIFF
--- a/es5-sham.js
+++ b/es5-sham.js
@@ -68,8 +68,15 @@ if (!Object.getPrototypeOf) {
             return proto;
         } else if (toStr(object.constructor) === '[object Function]') {
             return object.constructor.prototype;
+        } else if (!(object instanceof Object)) {
+          // Correctly return null for Objects created with `Object.create(null)`
+          // (shammed or native) or `{ __proto__: null}`.  Also returns null for
+          // cross-realm objects on browsers that lack `__proto__` support (like
+          // IE <11), but that's the best we can do.
+          return null;
+        } else {
+          return prototypeOfObject;
         }
-        return prototypeOfObject;
     };
 }
 
@@ -274,9 +281,6 @@ if (!Object.create) {
             delete empty.toLocaleString;
             delete empty.toString;
             delete empty.valueOf;
-            /* eslint-disable no-proto */
-            empty.__proto__ = null;
-            /* eslint-enable no-proto */
 
             var Empty = function Empty() {};
             Empty.prototype = empty;

--- a/tests/spec/s-object.js
+++ b/tests/spec/s-object.js
@@ -312,6 +312,12 @@ describe('Object', function () {
                 expect(err).toEqual(jasmine.any(TypeError));
             }
         });
+
+        it('should return null on Object.create(null)', function () {
+            var obj = Object.create(null);
+
+            expect(Object.getPrototypeOf(obj)).toBe(null);
+        });
     });
 
     describe('Object.defineProperties', function () {
@@ -324,6 +330,26 @@ describe('Object', function () {
             };
             Object.defineProperties(target, newProperties);
             expect(target.constructor).toEqual('new constructor');
+        });
+    });
+
+    describe('Object.create', function () {
+        it('should create objects with no properties when called as `Object.create(null)`', function () {
+            var obj = Object.create(null);
+
+            expect('hasOwnProperty' in obj).toBe(false);
+            expect('toString' in obj).toBe(false);
+            expect('constructor' in obj).toBe(false);
+
+            var protoIsEnumerable = false;
+            for (var k in obj) {
+                if (k === '__proto__') {
+                    protoIsEnumerable = true;
+                }
+            }
+            expect(protoIsEnumerable).toBe(false);
+
+            expect(obj instanceof Object).toBe(false);
         });
     });
 });


### PR DESCRIPTION
Background:
Object.create(null) is great, because it creates objects whose key
space is not polluted by names like "toString" and "constructor".
In addition, in modern browsers, objects created with
Object.create(null) do not even have a `__proto__` property!  This means
`'__proto__' in x` is false and `x.__proto__ === undefined` when
`x = Object.create(null)`.  Browsers extend this courtesy even further;
if you even set `x.__proto__ = null` at any time, the `__proto__` property
of x loses its special meaning and becomes safe to assign without
actually changing the internal prototype pointer of x.

The Object.create sham uses a very clever technique to create "nullary"
objects in browsers that don't support `__proto__` (like IE <11).
However, it then turns around and sets a property named `__proto__` on the
object!  Note that the code has already determined that this property
has no special meaning.

This commit simply removes the assignment to `__proto__`, so that
`'__proto__' in x` is false and `x.__proto__ === undefined`, as it
should be.

See live correctness test at: http://es5-sham-create-null.meteor.com

See #301.