### PR TITLE
Remove unnecessary Date constructor property

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -1093,8 +1093,6 @@ if (!Date.parse || doesNotParseY2KNewYear || acceptsInvalidDates || !supportsExt
             } else {
                 date = NativeDate.apply(this, arguments);
             }
-            // Prevent mixups with unfixed Date object
-            defineProperties(date, { constructor: DateShim }, true);
             return date;
         };
 


### PR DESCRIPTION
I question whether this code does anything useful given the presence of `Date.prototype.constructor`.  It actually broke a unit test in our of libraries, for obscure reasons, because it causes `(new Date).hasOwnProperty("constructor")` to return true.

I wonder what sort of mix-ups it is supposed to prevent?