### PR TITLE
PropertyIsEnumerable and hasOwnProperty method fails when you use the Object.create function in Internet Explorer

### DIFF
--- a/tests/spec/s-object.js
+++ b/tests/spec/s-object.js
@@ -355,5 +355,12 @@ describe('Object', function () {
 
             expect(obj instanceof Object).toBe(false);
         });
+        // https://support.microsoft.com/en-gb/kb/2980015
+        it('has Microsoft bug (2980015)', function () {
+            var obj = Object.create({});
+            obj[0] = 1;
+            expect(obj.hasOwnProperty('0')).toBe(true);
+            expect(obj.propertyIsEnumerable('0')).toBe(true);
+        });
     });
 });


### PR DESCRIPTION
https://support.microsoft.com/en-gb/kb/2980015
http://webreflection.blogspot.se/2014/04/all-ie-objects-are-broken.html
IE9 on saucelabs failed, but IE 10 & 11 have been patched and passed.