### PR TITLE
Add tests to `error` to confirm non-enumerability.

### DIFF
--- a/tests/spec/s-error.js
+++ b/tests/spec/s-error.js
@@ -19,10 +19,36 @@ describe('Error', function () {
                 throw new RangeError(msg);
             } catch (e) {
                 error = e;
-            };
+            }
             expect(error.name).toBe('RangeError');
             expect(error.message).toBe(msg);
             expect(String(error)).toBe(error.name + ': ' + msg);
+        });
+    });
+
+    describe('has properties that are not enummerable', function () {
+        it('message', function () {
+            expect(Error.prototype.propertyIsEnumerable('message')).toBe(false);
+            var obj = new Error('test');
+            expect(obj.propertyIsEnumerable('message')).toBe(false);
+        });
+
+        it('name', function () {
+            expect(Error.prototype.propertyIsEnumerable('name')).toBe(false);
+            var obj = new Error('test');
+            expect(obj.propertyIsEnumerable('name')).toBe(false);
+        });
+
+        it('stack', function () {
+            expect(Error.prototype.propertyIsEnumerable('stack')).toBe(false);
+            var obj = new Error('test');
+            expect(obj.propertyIsEnumerable('stack')).toBe(false);
+        });
+
+        it('stacktrace', function () {
+            expect(Error.prototype.propertyIsEnumerable('stacktrace')).toBe(false);
+            var obj = new Error('test');
+            expect(obj.propertyIsEnumerable('stacktrace')).toBe(false);
         });
     });
 });


### PR DESCRIPTION
IE < 9 (IE 8 possibly fixable)
IE9
Opera 11 & 12
FireFox 4-27

Some of this is inconsistencies rather than spec.