### PR TITLE
Add a rule to `.gitignore` to ignore Komodo Edit settings for the project.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+*.komodoproject


### PR DESCRIPTION
This would be very useful so that users using `Komodo Edit` don't accidentally upload their editor settings when working on `es5-shim`.