### PR TITLE
Tests for RegExp, toString should return correct flags and in correct order

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -27,6 +27,7 @@
 	<script src="spec/s-number.js"></script>
 	<script src="spec/s-object.js"></script>
 	<script src="spec/s-string.js"></script>
+	<script src="spec/s-regexp.js"></script>
 
 
 	<script type="text/javascript">

--- a/tests/native.html
+++ b/tests/native.html
@@ -23,6 +23,7 @@
 	<script src="spec/s-number.js"></script>
 	<script src="spec/s-object.js"></script>
 	<script src="spec/s-string.js"></script>
+	<script src="spec/s-regexp.js"></script>
 
 
 	<script type="text/javascript">

--- a/tests/spec/s-regexp.js
+++ b/tests/spec/s-regexp.js
@@ -1,0 +1,26 @@
+/* global describe, it, expect */
+
+describe('RegExp', function () {
+    'use strict';
+
+    describe('#toString()', function () {
+        describe('literals', function () {
+          it('should return correct flags and in correct order', function () {
+              expect(/pattern/.toString()).toBe('/pattern/');
+              expect(/pattern/i.toString()).toBe('/pattern/i');
+              expect(/pattern/mi.toString()).toBe('/pattern/im');
+              expect(/pattern/im.toString()).toBe('/pattern/im');
+              expect(/pattern/mgi.toString()).toBe('/pattern/gim');
+          });
+        });
+        describe('objects', function () {
+          it('should return correct flags and in correct order', function () {
+              expect(new RegExp('pattern').toString()).toBe('/pattern/');
+              expect(new RegExp('pattern', 'i').toString()).toBe('/pattern/i');
+              expect(new RegExp('pattern', 'mi').toString()).toBe('/pattern/im');
+              expect(new RegExp('pattern', 'im').toString()).toBe('/pattern/im');
+              expect(new RegExp('pattern', 'mgi').toString()).toBe('/pattern/gim');
+          });
+        });
+    });
+});


### PR DESCRIPTION
IE8 fails this.
Can be fixed by creating from `source` and using flags.
```
  function regExpToString(value) {
    var str = '/' + value.source + '/';
    if (value.global) {
      str += 'g';
    }
    if (value.ignoreCase) {
      str += 'i';
    }
    if (value.multiline) {
      str += 'm';
    }
    if (value.sticky) {
      str += 'y';
    }
    return str;
  }
```