### PR TITLE
Check if property descriptor is configurable before re-defining it

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -2017,8 +2017,10 @@ if (supportsDescriptors) {
     var ensureNonEnumerable = function (obj, prop) {
         if (isEnum(obj, prop)) {
             var desc = Object.getOwnPropertyDescriptor(obj, prop);
-            desc.enumerable = false;
-            Object.defineProperty(obj, prop, desc);
+            if (desc.configurable) {
+              desc.enumerable = false;
+              Object.defineProperty(obj, prop, desc);
+            }
         }
     };
     ensureNonEnumerable(Error.prototype, 'message');


### PR DESCRIPTION
Android Browser 4.0 appears to have a non-configurable Error.prototype.name property - 

```js
Object.getOwnPropertyDescriptor(Error.prototype, 'name')
// returns - 
{"value":"Error", "writable": false, "enumerable": false, "configurable": false}
```

and will raise a (confusingly-name) "Cannot redefine property: defineProperty" error if you try to re-define Error.prototype.name.

How about checking for `desc.configurable` before attempting to call `Object.defineProperty` ?

This fixes #373 