### PR TITLE
es5-shim.js: fix issue #412

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -1885,13 +1885,13 @@
             if (!isFn || !hasCapturingGroups) {
                 return str_replace.call(this, searchValue, replaceValue);
             } else {
-                var wrappedReplaceValue = function (match) {
-                    var length = arguments.length;
-                    var originalLastIndex = searchValue.lastIndex;
-                    searchValue.lastIndex = 0;
-                    var args = searchValue.exec(match) || [];
-                    searchValue.lastIndex = originalLastIndex;
-                    pushCall(args, arguments[length - 2], arguments[length - 1]);
+                var wrappedReplaceValue = function () {
+                    var args = [];
+
+                    for (var i = 0; i < arguments.length; i++) {
+                        args[i] = arguments[i] === '' ? undefined : arguments[i];
+                    }
+
                     return replaceValue.apply(this, args);
                 };
                 return str_replace.call(this, searchValue, wrappedReplaceValue);


### PR DESCRIPTION
Pass arguments to the original function

I have noticed that this [decorator](https://github.com/es-shims/es5-shim/blob/master/es5-shim.js#L1888) does not correct [problems](https://github.com/es-shims/es5-shim/blob/master/es5-shim.js#L1873) that are checked.

Background and reasons are:
In [1878 line](https://github.com/es-shims/es5-shim/blob/master/es5-shim.js#L1878) it is checked, that in the case of a capturing group with quantifiers preventing its exercise, the matched text for a capturing group has to be `undefined`, but there is no any correction.
However, the only one thing that is needed here is to correct types of missing groups, and pass all arguments to the original function.
