### PR TITLE
Tell greenkeeper.io to ignore uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
     "javascript",
     "ecmascript",
     "polyfill"
-  ]
+  ],
+  "greenkeeper": {
+    "ignore": [
+      "uglify-js"
+    ]
+  }
 }
 


### PR DESCRIPTION
Last 15 PR were from greenkeeper.io bot tryting to update uglify-js, all of them were closed with a comment saying: "uglify does not follow semver".