### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#es5-shim <sup>[![Version Badge][npm-version-svg]][npm-url]</sup>
+# es5-shim <sup>[![Version Badge][npm-version-svg]][npm-url]</sup>
 
 [![npm badge][npm-badge-png]][npm-url]
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
