### PR TITLE
🐛 Fix: Accessing window.top.{constructor|prototype} from a frame throws error in iOS

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -994,7 +994,8 @@
         $webkitStorageInfo: true,
         $external: true,
         $width: true,
-        $height: true
+        $height: true,
+        $top: true
     };
     var hasAutomationEqualityBug = (function () {
         /* globals window */

--- a/tests/spec/s-object.js
+++ b/tests/spec/s-object.js
@@ -140,7 +140,7 @@ describe('Object', function () {
 
         ifWindowIt('can serialize all objects on the `window`', function () {
             var windowItemKeys, exception;
-            var excludedKeys = ['window', 'console', 'parent', 'self', 'frame', 'frames', 'frameElement', 'external', 'height', 'width'];
+            var excludedKeys = ['window', 'console', 'parent', 'self', 'frame', 'frames', 'frameElement', 'external', 'height', 'width', 'top'];
             if (supportsDescriptors) {
                 Object.defineProperty(window, 'thrower', {
                     configurable: true,


### PR DESCRIPTION
Prevent accessing `window.top` so that no security errors are thrown when es5-shim is used in an iframe from a different domain