### PR TITLE
Check for module's existence instead of exports

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -18,7 +18,7 @@
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(factory);
-    } else if (typeof exports === 'object') {
+    } else if (typeof module === 'object') {
         // Node. Does not work with strict CommonJS, but
         // only CommonJS-like enviroments that support module.exports,
         // like Node.


### PR DESCRIPTION
The library should be checking for `module` existence instead of `exports` existence. It has happened to us that in the browser for whatever reason `exports` was pointing to `Window` and the module check failed on `Module is not defined` on line 25 in this file. Also it doesn't make sense to check for variable `A` and then writing to variable `B` (I know they're aliases in Node, but that's not the case in browser).