### PR TITLE
[Fix] exclude deprecated Firefox keys

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -1015,6 +1015,8 @@
         $frames: true,
         $innerHeight: true,
         $innerWidth: true,
+        $onmozfullscreenchange: true,
+        $onmozfullscreenerror: true,
         $outerHeight: true,
         $outerWidth: true,
         $pageXOffset: true,


### PR DESCRIPTION
Exclude deprecated Firefox keys. Fixes #459, and is a similar fix to https://github.com/ljharb/object-keys/pull/53