### PR TITLE
handle no `deleteCount` to `splice()` in Opera

### DIFF
--- a/es5-shim.js
+++ b/es5-shim.js
@@ -821,7 +821,11 @@
             var len = ES.ToUint32(O.length);
             var relativeStart = ES.ToInteger(start);
             var actualStart = relativeStart < 0 ? max((len + relativeStart), 0) : min(relativeStart, len);
-            var actualDeleteCount = min(max(ES.ToInteger(deleteCount), 0), len - actualStart);
+            var actualDeleteCount = arguments.length === 0
+                ? 0
+                : arguments.length === 1
+                    ? len - actualStart
+                    : min(max(ES.ToInteger(deleteCount), 0), len - actualStart);
 
             var k = 0;
             var from;

--- a/tests/spec/s-array.js
+++ b/tests/spec/s-array.js
@@ -1368,6 +1368,12 @@ describe('Array', function () {
             expect(test.splice(0)).toEqual(test.splice(0, 0));
         });
 
+        // ES6 introduced a proper default value
+        it('defaults deleteCount to length - start if there is only 1 argument', function () {
+            expect([0, 1, 2].splice(0).length).toBe(3);
+            expect([0, 1, 2].splice(1).length).toBe(2);
+        });
+
         it('basic implementation test 1', function () {
             expect(test.splice(0, 0)).toEqual([]);
         });


### PR DESCRIPTION
In Opera 10.6 and 9.8, when the fix is applied and `deleteCount` is missing, no elements are deleted.
This is incorrect - when `deleteCount` is missing the behavior should be to delete all elements from `start` onwards